### PR TITLE
Update Dockerfile to use Rust 1.78 for compatibility with dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.77.2-alpine3.19 as chef
+FROM docker.io/rust:1.78-alpine3.19 as chef
 RUN apk add --no-cache alpine-sdk
 RUN cargo install cargo-chef
 WORKDIR /usr/src/lrclib


### PR DESCRIPTION
This PR updates the base Docker image from `rust:1.77.2-alpine3.19` to `rust:1.78-alpine3.19` to address compatibility issues with certain dependencies that require Rust version 1.78 or higher. Specifically, the `cargo-platform` package requires `rustc` version 1.78, which was not available in the previous image, causing build failures.

## Reason for Change:

- Compatibility: The updated image ensures compatibility with the required Rust version for the dependencies.
- Tested with Docker: The changes have been tested using Docker (not Podman), and the build process works successfully with the updated image.
- 
This change ensures that the project can be built and run without errors related to the Rust version.

