### PR TITLE
Add support for ISRCs

### DIFF
--- a/server/src/entities/lyrics.rs
+++ b/server/src/entities/lyrics.rs
@@ -11,6 +11,7 @@ pub struct Lyrics {
   pub source: Option<String>,
   pub created_at: Option<DateTime<Utc>>,
   pub updated_at: Option<DateTime<Utc>>,
+  pub isrcs: Option<Vec<String>>,
 }
 
 pub struct SimpleLyrics {

--- a/server/src/entities/track.rs
+++ b/server/src/entities/track.rs
@@ -11,6 +11,7 @@ pub struct Track {
   pub last_lyrics: Option<SimpleLyrics>,
   pub created_at: Option<DateTime<Utc>>,
   pub updated_at: Option<DateTime<Utc>>,
+  pub isrcs: Option<Vec<String>>,
 }
 
 pub struct SimpleTrack {
@@ -20,4 +21,5 @@ pub struct SimpleTrack {
   pub artist_name: Option<String>,
   pub duration: Option<f64>,
   pub last_lyrics: Option<SimpleLyrics>,
+  pub isrcs: Option<Vec<String>>,
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -91,6 +91,7 @@ pub async fn serve(port: u16, database: &PathBuf, workers_count: u8) {
   let api_routes = Router::new()
     .route("/get", get(get_lyrics_by_metadata::route))
     .route("/get/:track_id", get(get_lyrics_by_track_id::route))
+    .route("/get/:isrc", get(get_lyrics_by_isrc::route))
     .route("/search", get(search_lyrics::route))
     .route("/request-challenge", post(request_challenge::route))
     .route("/publish", post(publish_lyrics::route))

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -17,6 +17,7 @@ use r2d2_sqlite::SqliteConnectionManager;
 use routes::{
   get_lyrics_by_metadata,
   get_lyrics_by_track_id,
+  get_lyrics_by_isrc,
   search_lyrics,
   request_challenge,
   publish_lyrics,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -92,7 +92,7 @@ pub async fn serve(port: u16, database: &PathBuf, workers_count: u8) {
   let api_routes = Router::new()
     .route("/get", get(get_lyrics_by_metadata::route))
     .route("/get/:track_id", get(get_lyrics_by_track_id::route))
-    .route("/get/:isrc", get(get_lyrics_by_isrc::route))
+    .route("/get/isrc/:isrc", get(get_lyrics_by_isrc::route))
     .route("/search", get(search_lyrics::route))
     .route("/request-challenge", post(request_challenge::route))
     .route("/publish", post(publish_lyrics::route))

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -192,16 +192,22 @@ async fn shutdown_signal() {
             .expect("failed to install Ctrl+C handler");
     };
 
-    #[cfg(unix)]
-    let terminate = async {
+    #[cfg(unix)] {
+      let terminate = async {
         signal::unix::signal(signal::unix::SignalKind::terminate())
             .expect("failed to install signal handler")
             .recv()
             .await;
-    };
-
-    tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+      };
+      tokio::select! {
+          _ = ctrl_c => {},
+          _ = terminate => {},
+      }
     }
+
+    #[cfg(not(unix))]
+    {
+        ctrl_c.await;
+    }
+
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -22,6 +22,7 @@ use routes::{
   request_challenge,
   publish_lyrics,
   flag_lyrics,
+  submit_isrcs
 };
 use std::sync::Arc;
 use db::init_db;
@@ -96,8 +97,8 @@ pub async fn serve(port: u16, database: &PathBuf, workers_count: u8) {
     .route("/search", get(search_lyrics::route))
     .route("/request-challenge", post(request_challenge::route))
     .route("/publish", post(publish_lyrics::route))
-    .route("/flag", post(flag_lyrics::route));
-
+    .route("/flag", post(flag_lyrics::route))
+    .route("/submit-isrcs", post(submit_isrcs::route));
   // Metrics
   tokio::spawn(async move {
     tokio::time::sleep(Duration::from_secs(60)).await;

--- a/server/src/queue.rs
+++ b/server/src/queue.rs
@@ -121,6 +121,7 @@ async fn add_found(missing_track: &MissingTrack, data: &ScrapedData, conn: &mut 
     &missing_track.artist_name.trim(),
     &missing_track.album_name.trim(),
     missing_track.duration,
+    None,
     &mut tx,
   )?;
 

--- a/server/src/repositories/track_repository.rs
+++ b/server/src/repositories/track_repository.rs
@@ -1,15 +1,15 @@
-use anyhow::Result;
-use rusqlite::{Connection, OptionalExtension, Transaction};
-use indoc::indoc;
 use crate::{
-  entities::{lyrics::SimpleLyrics, track::SimpleTrack},
-  utils::prepare_input,
+    entities::{lyrics::SimpleLyrics, track::SimpleTrack},
+    utils::prepare_input,
 };
+use anyhow::Result;
 use chrono::prelude::*;
+use indoc::indoc;
 use rusqlite::params_from_iter;
+use rusqlite::{Connection, OptionalExtension, Transaction};
 
 pub fn get_track_by_id(track_id: i64, conn: &mut Connection) -> Result<Option<SimpleTrack>> {
-  let query = indoc! {"
+    let query = indoc! {"
     SELECT
       tracks.id,
       tracks.name,
@@ -17,6 +17,7 @@ pub fn get_track_by_id(track_id: i64, conn: &mut Connection) -> Result<Option<Si
       tracks.artist_name,
       tracks.duration,
       tracks.last_lyrics_id,
+      tracks.isrcs,
       lyrics.instrumental,
       lyrics.plain_lyrics,
       lyrics.synced_lyrics
@@ -26,40 +27,109 @@ pub fn get_track_by_id(track_id: i64, conn: &mut Connection) -> Result<Option<Si
     WHERE
       tracks.id = ?
   "};
-  let mut statement = conn.prepare(query)?;
-  let row = statement.query_row(
-    [track_id],
-    |row| {
-      let instrumental = match row.get("instrumental")? {
-        Some(value) => value,
-        None => false
-      };
+    let mut statement = conn.prepare(query)?;
+    let row = statement
+        .query_row([track_id], |row| {
+            let instrumental = match row.get("instrumental")? {
+                Some(value) => value,
+                None => false,
+            };
 
-      let last_lyrics = SimpleLyrics {
-        plain_lyrics: row.get("plain_lyrics")?,
-        synced_lyrics: row.get("synced_lyrics")?,
-        instrumental,
-      };
+            let last_lyrics = SimpleLyrics {
+                plain_lyrics: row.get("plain_lyrics")?,
+                synced_lyrics: row.get("synced_lyrics")?,
+                instrumental,
+            };
 
-      Ok(SimpleTrack {
-        id: row.get("id")?,
-        name: row.get("name")?,
-        artist_name: row.get("artist_name")?,
-        album_name: row.get("album_name")?,
-        duration: row.get("duration")?,
-        last_lyrics: Some(last_lyrics),
-      })
-    }
-  ).optional()?;
-  Ok(row)
+            let isrcs: Option<String> = row.get("isrcs")?;
+            let isrcs_vec = isrcs
+                .as_ref()
+                .and_then(|s| serde_json::from_str(s).ok());
+
+            Ok(SimpleTrack {
+                id: row.get("id")?,
+                name: row.get("name")?,
+                artist_name: row.get("artist_name")?,
+                album_name: row.get("album_name")?,
+                duration: row.get("duration")?,
+                last_lyrics: Some(last_lyrics),
+                isrcs: isrcs_vec,
+            })
+        })
+        .optional()?;
+    Ok(row)
 }
 
-pub fn get_track_id_by_metadata(track_name: &str, artist_name: &str, album_name: &str, duration: f64, conn: &mut Connection) -> Result<Option<i64>> {
-  let track_name_lower = prepare_input(track_name);
-  let artist_name_lower = prepare_input(artist_name);
-  let album_name_lower = prepare_input(album_name);
+pub fn get_track_by_isrc(isrc: String, conn: &mut Connection) -> Result<Option<SimpleTrack>> {
+    let query = indoc! {"
+    SELECT
+      tracks.id,
+      tracks.name,
+      tracks.album_name,
+      tracks.artist_name,
+      tracks.duration,
+      tracks.last_lyrics_id,
+      tracks.isrcs,
+      lyrics.instrumental,
+      lyrics.plain_lyrics,
+      lyrics.synced_lyrics
+    FROM
+      tracks
+      LEFT JOIN lyrics ON tracks.last_lyrics_id = lyrics.id
+  "};
+    let mut statement = conn.prepare(query)?;
+    let mut rows = statement.query([])?;
+    while let Some(row) = rows.next()? {
+        let isrcs: Option<String> = row.get("isrcs")?;
+        let isrcs_vec: Option<Vec<String>> = isrcs
+            .as_ref()
+            .and_then(|s| serde_json::from_str(s).ok());
 
-  let query = indoc! {"
+        // Check if the provided ISRC exists in the isrcs array
+        if let Some(ref vec) = isrcs_vec {
+            if !vec.iter().any(|i| i == &isrc) {
+                continue;
+            }
+        } else {
+            continue;
+        }
+
+        let instrumental = match row.get("instrumental")? {
+            Some(value) => value,
+            None => false,
+        };
+
+        let last_lyrics = SimpleLyrics {
+            plain_lyrics: row.get("plain_lyrics")?,
+            synced_lyrics: row.get("synced_lyrics")?,
+            instrumental,
+        };
+
+        return Ok(Some(SimpleTrack {
+            id: row.get("id")?,
+            name: row.get("name")?,
+            artist_name: row.get("artist_name")?,
+            album_name: row.get("album_name")?,
+            duration: row.get("duration")?,
+            last_lyrics: Some(last_lyrics),
+            isrcs: isrcs_vec,
+        }));
+    }
+    Ok(None)
+}
+
+pub fn get_track_id_by_metadata(
+    track_name: &str,
+    artist_name: &str,
+    album_name: &str,
+    duration: f64,
+    conn: &mut Connection,
+) -> Result<Option<i64>> {
+    let track_name_lower = prepare_input(track_name);
+    let artist_name_lower = prepare_input(artist_name);
+    let album_name_lower = prepare_input(album_name);
+
+    let query = indoc! {"
     SELECT
       tracks.id
     FROM
@@ -73,22 +143,34 @@ pub fn get_track_id_by_metadata(track_name: &str, artist_name: &str, album_name:
     ORDER BY
       tracks.id
   "};
-  let mut statement = conn.prepare(query)?;
-  let row = statement.query_row(
-    (track_name_lower, artist_name_lower, album_name_lower, duration - 2.0, duration + 2.0),
-    |row| {
-      Ok(row.get("id")?)
-    }
-  ).optional()?;
-  Ok(row)
+    let mut statement = conn.prepare(query)?;
+    let row = statement
+        .query_row(
+            (
+                track_name_lower,
+                artist_name_lower,
+                album_name_lower,
+                duration - 2.0,
+                duration + 2.0,
+            ),
+            |row| Ok(row.get("id")?),
+        )
+        .optional()?;
+    Ok(row)
 }
 
-pub fn get_track_id_by_metadata_tx(track_name: &str, artist_name: &str, album_name: &str, duration: f64, conn: &mut Transaction) -> Result<Option<i64>> {
-  let track_name_lower = prepare_input(track_name);
-  let artist_name_lower = prepare_input(artist_name);
-  let album_name_lower = prepare_input(album_name);
+pub fn get_track_id_by_metadata_tx(
+    track_name: &str,
+    artist_name: &str,
+    album_name: &str,
+    duration: f64,
+    conn: &mut Transaction,
+) -> Result<Option<i64>> {
+    let track_name_lower = prepare_input(track_name);
+    let artist_name_lower = prepare_input(artist_name);
+    let album_name_lower = prepare_input(album_name);
 
-  let query = indoc! {"
+    let query = indoc! {"
     SELECT
       tracks.id
     FROM
@@ -102,25 +184,31 @@ pub fn get_track_id_by_metadata_tx(track_name: &str, artist_name: &str, album_na
     ORDER BY
       tracks.id
   "};
-  let mut statement = conn.prepare(query)?;
-  let row = statement.query_row(
-    (track_name_lower, artist_name_lower, album_name_lower, duration - 2.0, duration + 2.0),
-    |row| {
-      Ok(row.get("id")?)
-    }
-  ).optional()?;
-  Ok(row)
+    let mut statement = conn.prepare(query)?;
+    let row = statement
+        .query_row(
+            (
+                track_name_lower,
+                artist_name_lower,
+                album_name_lower,
+                duration - 2.0,
+                duration + 2.0,
+            ),
+            |row| Ok(row.get("id")?),
+        )
+        .optional()?;
+    Ok(row)
 }
 
 pub fn get_track_by_metadata(
-  track_name_lower: &str,
-  artist_name_lower: &str,
-  album_name_lower: Option<&str>,
-  duration: Option<f64>,
-  conn: &mut Connection,
+    track_name_lower: &str,
+    artist_name_lower: &str,
+    album_name_lower: Option<&str>,
+    duration: Option<f64>,
+    conn: &mut Connection,
 ) -> Result<Option<SimpleTrack>> {
-  // Start building the SQL query
-  let select_query = indoc! {"
+    // Start building the SQL query
+    let select_query = indoc! {"
     SELECT
       tracks.id,
       tracks.name,
@@ -128,6 +216,7 @@ pub fn get_track_by_metadata(
       tracks.album_name,
       tracks.duration,
       tracks.last_lyrics_id,
+      tracks.isrcs,
       lyrics.instrumental,
       lyrics.plain_lyrics,
       lyrics.synced_lyrics
@@ -136,102 +225,113 @@ pub fn get_track_by_metadata(
       LEFT JOIN lyrics ON tracks.last_lyrics_id = lyrics.id
   "};
 
-  // Initialize where clauses and parameters
-  let mut where_clauses = vec![
-    "tracks.name_lower = ?".to_string(),
-    "tracks.artist_name_lower = ?".to_string(),
-  ];
-  let mut params: Vec<rusqlite::types::Value> = vec![
-    track_name_lower.to_string().into(),
-    artist_name_lower.to_string().into(),
-  ];
+    // Initialize where clauses and parameters
+    let mut where_clauses = vec![
+        "tracks.name_lower = ?".to_string(),
+        "tracks.artist_name_lower = ?".to_string(),
+    ];
+    let mut params: Vec<rusqlite::types::Value> = vec![
+        track_name_lower.to_string().into(),
+        artist_name_lower.to_string().into(),
+    ];
 
-  // Conditionally add duration constraints
-  if let Some(dur) = duration {
-    let duration_min = dur - 2.0;
-    let duration_max = dur + 2.0;
-    where_clauses.push("tracks.duration >= ?".to_string());
-    where_clauses.push("tracks.duration <= ?".to_string());
-    params.push(duration_min.into());
-    params.push(duration_max.into());
-  }
-
-  // Conditionally add album_name to the query
-  if let Some(album_name_lower) = album_name_lower {
-    where_clauses.push("tracks.album_name_lower = ?".to_string());
-    params.push(album_name_lower.to_string().into());
-  }
-
-  // Combine all parts of the query
-  let query = format!(
-    "{select} WHERE {where_clause} ORDER BY tracks.id",
-    select = select_query,
-    where_clause = where_clauses.join(" AND ")
-  );
-
-  // Prepare and execute the statement
-  let mut statement = conn.prepare(&query)?;
-  let row = statement.query_row(
-    params_from_iter(params.iter().map(|v| v as &dyn rusqlite::ToSql)),
-    |row| {
-      let instrumental = row.get::<_, Option<bool>>("instrumental")?.unwrap_or(false);
-
-      let last_lyrics = SimpleLyrics {
-        plain_lyrics: row.get("plain_lyrics")?,
-        synced_lyrics: row.get("synced_lyrics")?,
-        instrumental,
-      };
-
-      Ok(SimpleTrack {
-        id: row.get("id")?,
-        name: row.get("name")?,
-        artist_name: row.get("artist_name")?,
-        album_name: row.get("album_name")?,
-        duration: row.get("duration")?,
-        last_lyrics: Some(last_lyrics),
-      })
+    // Conditionally add duration constraints
+    if let Some(dur) = duration {
+        let duration_min = dur - 2.0;
+        let duration_max = dur + 2.0;
+        where_clauses.push("tracks.duration >= ?".to_string());
+        where_clauses.push("tracks.duration <= ?".to_string());
+        params.push(duration_min.into());
+        params.push(duration_max.into());
     }
-  ).optional()?;
 
-  Ok(row)
+    // Conditionally add album_name to the query
+    if let Some(album_name_lower) = album_name_lower {
+        where_clauses.push("tracks.album_name_lower = ?".to_string());
+        params.push(album_name_lower.to_string().into());
+    }
+
+    // Combine all parts of the query
+    let query = format!(
+        "{select} WHERE {where_clause} ORDER BY tracks.id",
+        select = select_query,
+        where_clause = where_clauses.join(" AND ")
+    );
+
+    // Prepare and execute the statement
+    let mut statement = conn.prepare(&query)?;
+    let row = statement
+        .query_row(
+            params_from_iter(params.iter().map(|v| v as &dyn rusqlite::ToSql)),
+            |row| {
+                let instrumental = row.get::<_, Option<bool>>("instrumental")?.unwrap_or(false);
+
+                let last_lyrics = SimpleLyrics {
+                    plain_lyrics: row.get("plain_lyrics")?,
+                    synced_lyrics: row.get("synced_lyrics")?,
+                    instrumental,
+                };
+
+                let isrcs: Option<String> = row.get("isrcs")?;
+                let isrcs_vec = isrcs
+                    .as_ref()
+                    .and_then(|s| serde_json::from_str(s).ok());
+
+                Ok(SimpleTrack {
+                    id: row.get("id")?,
+                    name: row.get("name")?,
+                    artist_name: row.get("artist_name")?,
+                    album_name: row.get("album_name")?,
+                    duration: row.get("duration")?,
+                    last_lyrics: Some(last_lyrics),
+                    isrcs: isrcs_vec,
+                })
+            },
+        )
+        .optional()?;
+
+    Ok(row)
 }
 
 pub fn get_tracks_by_keyword(
-  q: Option<&str>,
-  track_name: Option<&str>,
-  artist_name: Option<&str>,
-  album_name: Option<&str>,
-  conn: &mut Connection,
+    q: Option<&str>,
+    track_name: Option<&str>,
+    artist_name: Option<&str>,
+    album_name: Option<&str>,
+    isrc: Option<&str>,
+    conn: &mut Connection,
 ) -> Result<Vec<SimpleTrack>> {
-  // To search track by keyword, at least q or track_name must be present
-  if q.is_none() && track_name.is_none() {
-    return Ok(vec![])
-  }
+    // To search track by keyword, at least q or track_name must be present
+    if q.is_none() && track_name.is_none() {
+        return Ok(vec![]);
+    }
 
-  // Determine whether to include ORDER BY rank based on the number of words in q or track_name
-  let is_ordered = if let Some(query) = q {
-    query.split_whitespace().count() > 3
-  } else if let (Some(track_name), None, None) = (track_name, artist_name, album_name) {
-    track_name.split_whitespace().count() > 3
-  } else {
-    true
-  };
+    // Determine whether to include ORDER BY rank based on the number of words in q or track_name
+    let is_ordered = if let Some(query) = q {
+        query.split_whitespace().count() > 3
+    } else if let (Some(track_name), None, None) = (track_name, artist_name, album_name) {
+        track_name.split_whitespace().count() > 3
+    } else {
+        true
+    };
 
-  // Build the subquery with or without ORDER BY rank
-  let subquery = if is_ordered {
-    indoc! {"SELECT rowid FROM tracks_fts WHERE tracks_fts MATCH ? ORDER BY rank LIMIT 20"}.to_string()
-  } else {
-    indoc! {"SELECT rowid FROM tracks_fts WHERE tracks_fts MATCH ? LIMIT 20"}.to_string()
-  };
+    // Build the subquery with or without ORDER BY rank
+    let subquery = if is_ordered {
+        indoc! {"SELECT rowid FROM tracks_fts WHERE tracks_fts MATCH ? ORDER BY rank LIMIT 20"}
+            .to_string()
+    } else {
+        indoc! {"SELECT rowid FROM tracks_fts WHERE tracks_fts MATCH ? LIMIT 20"}.to_string()
+    };
 
-  // Build the complete query using the subquery
-  let query = format!(
-    "SELECT
+    // Build the complete query using the subquery
+    let query = format!(
+        "SELECT
       tracks.id,
       tracks.name,
       tracks.artist_name,
       tracks.album_name,
       tracks.duration,
+      tracks.isrcs,
       lyrics.instrumental,
       lyrics.plain_lyrics,
       lyrics.synced_lyrics
@@ -240,75 +340,80 @@ pub fn get_tracks_by_keyword(
       LEFT JOIN tracks ON search_results.rowid = tracks.id
       LEFT JOIN lyrics ON tracks.last_lyrics_id = lyrics.id
     ",
-    subquery = subquery
-  );
+        subquery = subquery
+    );
 
-  let mut statement = conn.prepare(&query)?;
-  let fts_query = match q {
-    Some(q) => prepare_input(&q),
-    None => {
-      match track_name {
-        Some(track_name) => {
-          let mut result = format!("(name_lower : \"{}\")", track_name).to_owned();
-          if let Some(artist_name) = artist_name {
-            result.push_str(format!("AND (artist_name_lower : {})", artist_name).as_ref());
-          }
-          if let Some(album_name) = album_name {
-            result.push_str(format!("AND (album_name_lower : \"{}\")", album_name).as_ref());
-          }
-          result
+    let mut statement = conn.prepare(&query)?;
+    let fts_query = if let Some(isrc) = isrc {
+        format!("isrcs : \"{}\"", isrc)
+    } else if let Some(q) = q {
+        prepare_input(q)
+    } else if let Some(track_name) = track_name {
+        let mut result = format!("name_lower : \"{}\"", track_name);
+        if let Some(artist_name) = artist_name {
+            result.push_str(&format!(" AND artist_name_lower : \"{}\"", artist_name));
         }
-        None => "".to_owned()
-      }
+        if let Some(album_name) = album_name {
+            result.push_str(&format!(" AND album_name_lower : \"{}\"", album_name));
+        }
+        result
+    } else {
+        "".to_owned()
+    };
+
+    tracing::debug!("FTS query: {}", fts_query);
+
+    let mut rows = statement.query([fts_query])?;
+
+    let mut tracks = Vec::new();
+
+    while let Some(row) = rows.next()? {
+        let instrumental = match row.get("instrumental")? {
+            Some(value) => value,
+            None => false,
+        };
+
+        let last_lyrics = SimpleLyrics {
+            plain_lyrics: row.get("plain_lyrics")?,
+            synced_lyrics: row.get("synced_lyrics")?,
+            instrumental,
+        };
+
+        let isrcs: Option<String> = row.get("isrcs")?;
+        let isrcs_vec = isrcs
+            .as_ref()
+            .and_then(|s| serde_json::from_str(s).ok());
+
+        let track = SimpleTrack {
+            id: row.get("id")?,
+            name: row.get("name")?,
+            artist_name: row.get("artist_name")?,
+            album_name: row.get("album_name")?,
+            duration: row.get("duration")?,
+            last_lyrics: Some(last_lyrics),
+            isrcs: isrcs_vec,
+        };
+
+        tracks.push(track);
     }
-  };
 
-  tracing::debug!("FTS query: {}", fts_query);
-
-  let mut rows = statement.query([fts_query])?;
-
-  let mut tracks = Vec::new();
-
-  while let Some(row) = rows.next()? {
-    let instrumental = match row.get("instrumental")? {
-      Some(value) => value,
-      None => false
-    };
-
-    let last_lyrics = SimpleLyrics {
-      plain_lyrics: row.get("plain_lyrics")?,
-      synced_lyrics: row.get("synced_lyrics")?,
-      instrumental,
-    };
-
-    let track = SimpleTrack {
-      id: row.get("id")?,
-      name: row.get("name")?,
-      artist_name: row.get("artist_name")?,
-      album_name: row.get("album_name")?,
-      duration: row.get("duration")?,
-      last_lyrics: Some(last_lyrics),
-    };
-
-    tracks.push(track);
-  }
-
-  Ok(tracks)
+    Ok(tracks)
 }
 
 pub fn add_one(
-  track_name: &str,
-  artist_name: &str,
-  album_name: &str,
-  duration: f64,
-  conn: &mut Connection,
+    track_name: &str,
+    artist_name: &str,
+    album_name: &str,
+    duration: f64,
+    isrcs: Option<Vec<String>>,
+    conn: &mut Connection,
 ) -> Result<i64> {
-  let track_name_lower = prepare_input(track_name);
-  let artist_name_lower = prepare_input(artist_name);
-  let album_name_lower = prepare_input(album_name);
+    let track_name_lower = prepare_input(track_name);
+    let artist_name_lower = prepare_input(artist_name);
+    let album_name_lower = prepare_input(album_name);
 
-  let now = Utc::now();
-  let query = indoc! {"
+    let now = Utc::now();
+    let query = indoc! {"
     INSERT INTO tracks (
       name,
       name_lower,
@@ -317,41 +422,42 @@ pub fn add_one(
       album_name,
       album_name_lower,
       duration,
+      isrcs,
       created_at,
       updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   "};
-  let mut statement = conn.prepare(query)?;
-  let row_id = statement.insert(
-    (
-      track_name,
-      track_name_lower,
-      artist_name,
-      artist_name_lower,
-      album_name,
-      album_name_lower,
-      duration,
-      now,
-      now,
-    )
-  )?;
-  Ok(row_id)
+    let mut statement = conn.prepare(query)?;
+    let row_id = statement.insert((
+        track_name,
+        track_name_lower,
+        artist_name,
+        artist_name_lower,
+        album_name,
+        album_name_lower,
+        duration,
+        isrcs.as_ref().map(|v| serde_json::to_string(v).unwrap_or("[]".to_string())), // store as JSON
+        now,
+        now,
+    ))?;
+    Ok(row_id)
 }
 
 pub fn add_one_tx(
-  track_name: &str,
-  artist_name: &str,
-  album_name: &str,
-  duration: f64,
-  conn: &mut Transaction,
+    track_name: &str,
+    artist_name: &str,
+    album_name: &str,
+    duration: f64,
+    isrcs: Option<Vec<String>>,
+    conn: &mut Transaction,
 ) -> Result<i64> {
-  let track_name_lower = prepare_input(track_name);
-  let artist_name_lower = prepare_input(artist_name);
-  let album_name_lower = prepare_input(album_name);
+    let track_name_lower = prepare_input(track_name);
+    let artist_name_lower = prepare_input(artist_name);
+    let album_name_lower = prepare_input(album_name);
 
-  let now = Utc::now();
-  let query = indoc! {"
+    let now = Utc::now();
+    let query = indoc! {"
     INSERT INTO tracks (
       name,
       name_lower,
@@ -360,36 +466,36 @@ pub fn add_one_tx(
       album_name,
       album_name_lower,
       duration,
+      isrcs,
       created_at,
       updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   "};
-  let mut statement = conn.prepare(query)?;
-  let row_id = statement.insert(
-    (
-      track_name,
-      track_name_lower,
-      artist_name,
-      artist_name_lower,
-      album_name,
-      album_name_lower,
-      duration,
-      now,
-      now,
-    )
-  )?;
-  Ok(row_id)
+    let mut statement = conn.prepare(query)?;
+    let row_id = statement.insert((
+        track_name,
+        track_name_lower,
+        artist_name,
+        artist_name_lower,
+        album_name,
+        album_name_lower,
+        duration,
+        isrcs.as_ref().map(|v| serde_json::to_string(v).unwrap_or("[]".to_string())), // store as JSON
+        now,
+        now,
+    ))?;
+    Ok(row_id)
 }
 
 pub fn flag_track_last_lyrics(track_id: i64, content: &str, conn: &mut Connection) -> Result<()> {
-  let now = Utc::now();
+    let now = Utc::now();
 
-  let query = indoc! {"
+    let query = indoc! {"
     INSERT INTO flags (lyrics_id, content, created_at)
     SELECT last_lyrics_id, ?, ? FROM tracks WHERE id = ?
   "};
-  let mut statement = conn.prepare(query)?;
-  statement.execute((content, now, track_id))?;
-  Ok(())
+    let mut statement = conn.prepare(query)?;
+    statement.execute((content, now, track_id))?;
+    Ok(())
 }

--- a/server/src/repositories/track_repository.rs
+++ b/server/src/repositories/track_repository.rs
@@ -22,6 +22,22 @@ fn get_isrcs_for_track(
     Ok(isrcs)
 }
 
+pub fn submit_isrcs(
+    isrcs: &[String],
+    track_id: i64,
+    conn: &mut Connection,
+) -> Result<(), rusqlite::Error> {
+    let query = indoc! {"
+    INSERT OR IGNORE INTO isrcs (isrc, track_id)
+    VALUES (?, ?)
+  "};
+    let mut statement = conn.prepare(query)?;
+    for isrc in isrcs {
+        statement.execute((&**isrc, track_id))?;
+    }
+    Ok(())
+}
+
 pub fn get_track_by_id(track_id: i64, conn: &mut Connection) -> Result<Option<SimpleTrack>> {
     let query = indoc! {"
   SELECT

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -5,3 +5,4 @@ pub mod search_lyrics;
 pub mod request_challenge;
 pub mod publish_lyrics;
 pub mod flag_lyrics;
+pub mod submit_isrcs;

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1,5 +1,6 @@
 pub mod get_lyrics_by_metadata;
 pub mod get_lyrics_by_track_id;
+pub mod get_lyrics_by_isrc;
 pub mod search_lyrics;
 pub mod request_challenge;
 pub mod publish_lyrics;

--- a/server/src/routes/get_lyrics_by_isrc.rs
+++ b/server/src/routes/get_lyrics_by_isrc.rs
@@ -1,0 +1,65 @@
+use axum::{extract::{Path, State}, Json};
+use serde::Serialize;
+use crate::{entities::track::SimpleTrack, errors::ApiError, repositories::track_repository::get_track_by_isrc, AppState};
+use std::sync::Arc;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackResponse {
+  id: i64,
+  name: Option<String>,
+  track_name: Option<String>,
+  artist_name: Option<String>,
+  album_name: Option<String>,
+  duration: Option<f64>,
+  instrumental: bool,
+  plain_lyrics: Option<String>,
+  synced_lyrics: Option<String>,
+  isrcs: Option<Vec<String>>,
+}
+
+pub async fn route(Path(isrc): Path<String>, State(state): State<Arc<AppState>>) -> Result<Json<TrackResponse>, ApiError> {
+  let maybe_track = {
+    let mut conn = state.pool.get()?;
+    get_track_by_isrc(isrc, &mut conn)?
+  };
+
+  match maybe_track {
+    Some(track) => {
+      Ok(Json(create_response(track)))
+    }
+    None => {
+      Err(ApiError::TrackNotFoundError)
+    }
+  }
+}
+
+fn create_response(track: SimpleTrack) -> TrackResponse {
+  let plain_lyrics = match track.last_lyrics {
+    Some(ref lyrics) => lyrics.plain_lyrics.to_owned(),
+    None => None
+  };
+
+  let synced_lyrics = match track.last_lyrics {
+    Some(ref lyrics) => lyrics.synced_lyrics.to_owned(),
+    None => None
+  };
+
+  let instrumental = match track.last_lyrics {
+    Some(ref lyrics) => lyrics.instrumental.to_owned(),
+    None => false
+  };
+
+  TrackResponse {
+    id: track.id,
+    name: track.name.to_owned(),
+    track_name: track.name.to_owned(),
+    artist_name: track.artist_name.to_owned(),
+    album_name: track.album_name.to_owned(),
+    duration: track.duration,
+    instrumental,
+    plain_lyrics,
+    synced_lyrics,
+    isrcs: track.isrcs,
+  }
+}

--- a/server/src/routes/get_lyrics_by_isrc.rs
+++ b/server/src/routes/get_lyrics_by_isrc.rs
@@ -60,6 +60,6 @@ fn create_response(track: SimpleTrack) -> TrackResponse {
     instrumental,
     plain_lyrics,
     synced_lyrics,
-    isrcs: track.isrcs,
+    isrcs: track.isrcs.to_owned(),
   }
 }

--- a/server/src/routes/get_lyrics_by_metadata.rs
+++ b/server/src/routes/get_lyrics_by_metadata.rs
@@ -37,6 +37,7 @@ pub struct TrackResponse {
   instrumental: bool,
   plain_lyrics: Option<String>,
   synced_lyrics: Option<String>,
+  isrcs: Option<Vec<String>>,
 }
 
 #[debug_handler]
@@ -147,6 +148,7 @@ fn create_response(track: SimpleTrack) -> TrackResponse {
     instrumental,
     plain_lyrics,
     synced_lyrics,
+    isrcs: track.isrcs,
   }
 }
 

--- a/server/src/routes/get_lyrics_by_metadata.rs
+++ b/server/src/routes/get_lyrics_by_metadata.rs
@@ -148,7 +148,7 @@ fn create_response(track: SimpleTrack) -> TrackResponse {
     instrumental,
     plain_lyrics,
     synced_lyrics,
-    isrcs: track.isrcs,
+    isrcs: track.isrcs.to_owned(),
   }
 }
 

--- a/server/src/routes/get_lyrics_by_track_id.rs
+++ b/server/src/routes/get_lyrics_by_track_id.rs
@@ -15,6 +15,7 @@ pub struct TrackResponse {
   instrumental: bool,
   plain_lyrics: Option<String>,
   synced_lyrics: Option<String>,
+  isrcs: Option<Vec<String>>,
 }
 
 pub async fn route(Path(track_id): Path<i64>, State(state): State<Arc<AppState>>) -> Result<Json<TrackResponse>, ApiError> {
@@ -59,5 +60,6 @@ fn create_response(track: SimpleTrack) -> TrackResponse {
     instrumental,
     plain_lyrics,
     synced_lyrics,
+    isrcs: track.isrcs,
   }
 }

--- a/server/src/routes/get_lyrics_by_track_id.rs
+++ b/server/src/routes/get_lyrics_by_track_id.rs
@@ -60,6 +60,6 @@ fn create_response(track: SimpleTrack) -> TrackResponse {
     instrumental,
     plain_lyrics,
     synced_lyrics,
-    isrcs: track.isrcs,
+    isrcs: track.isrcs.to_owned(),
   }
 }

--- a/server/src/routes/publish_lyrics.rs
+++ b/server/src/routes/publish_lyrics.rs
@@ -28,6 +28,7 @@ pub struct PublishRequest {
     duration: f64,
     plain_lyrics: Option<String>,
     synced_lyrics: Option<String>,
+    isrcs: Option<Vec<String>>,
 }
 
 #[debug_handler]
@@ -73,6 +74,7 @@ fn publish_lyrics(payload: &PublishRequest, conn: &mut Connection) -> Result<()>
       &payload.artist_name.trim(),
       &payload.album_name.trim(),
       payload.duration,
+      payload.isrcs.clone(),
       &mut tx,
     )?
   };

--- a/server/src/routes/search_lyrics.rs
+++ b/server/src/routes/search_lyrics.rs
@@ -138,7 +138,7 @@ fn create_response(tracks: Vec<SimpleTrack>) -> Vec<TrackResponse> {
         instrumental,
         plain_lyrics,
         synced_lyrics,
-        isrcs: track.isrcs
+        isrcs: track.isrcs.to_owned(),
       }
     }
   ).collect()

--- a/server/src/routes/search_lyrics.rs
+++ b/server/src/routes/search_lyrics.rs
@@ -31,6 +31,7 @@ pub struct TrackResponse {
   instrumental: bool,
   plain_lyrics: Option<String>,
   synced_lyrics: Option<String>,
+  isrcs: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -132,6 +133,7 @@ fn create_response(tracks: Vec<SimpleTrack>) -> Vec<TrackResponse> {
         instrumental,
         plain_lyrics,
         synced_lyrics,
+        isrcs: track.isrcs
       }
     }
   ).collect()

--- a/server/src/routes/submit_isrcs.rs
+++ b/server/src/routes/submit_isrcs.rs
@@ -1,0 +1,49 @@
+use axum::{extract::State, http::{HeaderMap, StatusCode}, Json};
+use serde::{Deserialize, Serialize};
+use crate::{errors::ApiError, repositories::track_repository::submit_isrcs, AppState, utils::is_valid_publish_token};
+use std::sync::Arc;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackResponse {
+  id: i64,
+  name: Option<String>,
+  track_name: Option<String>,
+  artist_name: Option<String>,
+  album_name: Option<String>,
+  duration: Option<f64>,
+  instrumental: bool,
+  plain_lyrics: Option<String>,
+  synced_lyrics: Option<String>,
+  isrcs: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+pub struct SubmitISRCSRequest {
+    isrcs: Option<Vec<String>>,
+    track_id: i64,
+}
+
+pub async fn route(
+  headers: HeaderMap,
+  State(state): State<Arc<AppState>>,
+  Json(payload): Json<SubmitISRCSRequest>,
+) -> Result<StatusCode, ApiError> {
+  match headers.get("X-Publish-Token") {
+    Some(publish_token) => {
+      let is_valid = is_valid_publish_token(publish_token.to_str()?, &state.challenge_cache).await;
+
+      if is_valid {
+        let isrcs = payload.isrcs.as_deref().unwrap_or(&[]);
+        let track_id = payload.track_id;
+        let mut conn = state.pool.get()?;
+        submit_isrcs(isrcs, track_id, &mut conn)?;
+
+        Ok(StatusCode::CREATED)
+      } else {
+        Err(ApiError::IncorrectPublishTokenError)
+      }
+    },
+    None => Err(ApiError::IncorrectPublishTokenError)
+  }
+}


### PR DESCRIPTION
- Added `isrcs: Option<Vec<String>>` to `TrackResponse`
- Added new public methods `submit_isrcs` and `get_track_by_isrc` to `track_repository`
- Added new private method `get_isrcs_for_track` to `track_repository`
- Updated `get_track_by_id`, `get_track_by_metadata`, and `get_tracks_by_keyword` in `track_repository` to perform a lookup in the `isrcs` DB table after the first lookup in order to serve ISRCs in the `TrackResponse`
- Updated `add_one_tx`, and `add_one` in `track_repository` to insert ISRCs into the `isrcs` table when provided
   - Now accepts `isrcs` field when adding new track entry
- Added route `/get/isrc/?` at `get_lyrics_by_isrc.rs`
   - Accepts an ISRC 
   - Uses the `get_track_by_isrc` method
- Added route `/submit-isrcs`
   - Accepts `isrcs` and `track_id` as a payload
   - Requires a valid `X-Publish-Token` to submit an ISRC
      - POW rate limiting is bad but I'll make an issue about that later
- Updated `routes.rs` with new routes
- Updated `lib.rs` with new routes
- Updated `lib.rs` to fix non-unix support
- More things
  - Probably
  - Look at the diff