### PR TITLE
Make SQLite `mmap_size` and `cache_size` configurable via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ LRCLIB_LOG=info cargo run --release -- serve --database db.sqlite3
 
 Server will be available at http://0.0.0.0:3300
 
+## Database configuration
+
+You have two environment variables available to tweak the database connection:
+
+* `LRCLIB_MMAP_SIZE` (default `30000000000` - 30GB): set [SQLite's `mmap_size`](https://www.sqlite.org/mmap.html) parameter. This should be less than 75% of the available RAM. Using an excessive value might cause memory swapping, decreasing performance.
+* `LRCLIB_CACHE_SIZE` (default `-1000000` - 1GB): set [SQLite's `cache_size`](https://sqlite.org/pragma.html#pragma_cache_size) parameter. Negative values are kilobytes.
+
+Use these variables to optimize memory usage in low traffic and/or low memory situations. The default values are generously sized to be used on a production system.
+
 ## Setup with Podman/Docker
 
 ### Basic

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -30,7 +30,21 @@ pub fn set_pragma(conn: &mut Connection) -> Result<()> {
     conn.pragma_update(None, "journal_mode", "WAL")?;
     conn.pragma_update(None, "synchronous", "NORMAL")?;
     conn.pragma_update(None, "temp_store", "MEMORY")?;
-    conn.pragma_update(None, "mmap_size", "30000000000")?;
+    
+    let mmap_size = std::env::var("LRCLIB_MMAP_SIZE")
+        .ok()
+        .and_then(|val| val.parse::<i64>().ok())
+        .unwrap_or(30000000000i64)
+        .to_string();
+    conn.pragma_update(None, "mmap_size", &mmap_size)?;
+    
+    let cache_size = std::env::var("LRCLIB_CACHE_SIZE")
+        .ok()
+        .and_then(|val| val.parse::<i64>().ok())
+        .unwrap_or(-1000000i64)
+        .to_string();
+    conn.pragma_update(None, "cache_size", &cache_size)?;
+
     Ok(())
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -276,8 +276,9 @@ pub async fn serve_with_queue<F, Fut>(
         .await
         .unwrap();
 
-    println!(
-        "LRCLIB server is listening on {}!",
+     println!(
+        "LRCLIB server v{} is listening on {}!",
+        env!("CARGO_PKG_VERSION"),
         listener.local_addr().unwrap()
     );
 


### PR DESCRIPTION
* Add LRCLIB_MMAP_SIZE env var support with fallback to `30000000000` (30GB!)
* Add LRCLIB_CACHE_SIZE env var support with fallback to `-1000000` (1GB)
* Parse env vars as integers with validation for robustness
* Print version number in startup message

I decided not to change the massive `mmap_size` value, leaving this up to the maintainer. But I believe it should be set to some more reasonable value for dev work.