### PR TITLE
Add MCP (Model Context Protocol) support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /target
 /*.sqlite3*
 /queue-data*
+/lrclib-data

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /*.sqlite3*
 /queue-data*
+/lrclib-data

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -177,7 +177,9 @@ If you change matching behavior, review both:
   - `get_lyrics`: mirrors `GET /api/get` (track/artist/album/duration).
   - `get_lyrics_by_id`: mirrors `GET /api/get/:track_id`.
   - `search_lyrics`: mirrors `GET /api/search`, returns `{ tracks: [...] }` (MCP tool output schemas must be a JSON object at the root, so results are wrapped rather than returned as a bare array).
+- `mcp::TrackResponse` deliberately omits the `lyricsfile` raw-YAML field present on the REST `TrackResponse` structs: it's a redundant re-encoding of `plainLyrics`/`syncedLyrics`/`instrumental` with no extra information for a model to act on, so it's stripped to save tokens/context.
 - Tools call `repositories::track_repository` functions directly through `AppState::db_connection()`. They deliberately do **not** go through the HTTP-only `get_metadata_cache`/`search_cache` (those are keyed by cache-key builders private to the `/api` route handlers); MCP traffic is expected to be much lower than public HTTP traffic, so this was kept simple rather than sharing/refactoring the caching layer.
+- Each tool declares a `title` and `annotations(read_only_hint = true, open_world_hint = false)` (all three only read LRCLIB's own dataset, no side effects). `outputSchema` is derived automatically by `rmcp` from each tool's `Json<T>` return type.
 - Publish/flag are intentionally not exposed as MCP tools: they require a proof-of-work challenge/token flow (`request_challenge`, `utils::is_valid_publish_token`) that doesn't map cleanly onto a single tool call.
 
 ## Queue Status

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,6 +78,8 @@ Routes are mounted under `/api` in `server/src/lib.rs`.
 - `POST /api/flag`: flag current lyrics for a track.
 - `POST /api/manage/set-config`: update queue worker count.
 
+`/mcp` is a separate, non-REST endpoint: a Model Context Protocol (Streamable HTTP) server, see "MCP" below.
+
 ## Main Request Paths
 
 ### `GET /api/get`
@@ -164,6 +166,19 @@ If you change matching behavior, review both:
 
 - `utils::prepare_input`
 - repository metadata queries and FTS usage
+
+## MCP
+
+`server/src/mcp.rs` exposes a read-only Model Context Protocol server over Streamable HTTP, mounted at `/mcp` in `build_router` (`server/src/lib.rs`) alongside `/api`. It shares the same `TraceLayer`/`CorsLayer` and is unauthenticated, same as the read endpoints under `/api`.
+
+- `LrclibMcpServer` holds an `Arc<AppState>` and is constructed fresh per MCP session by `rmcp`'s `StreamableHttpService` factory.
+- `rmcp`'s DNS-rebinding protection (`Host` header allowlist, loopback-only by default) is disabled via `StreamableHttpServerConfig::disable_allowed_hosts()`, matching the open-CORS trust model of `/api`: the server is expected to run behind arbitrary reverse proxies/hostnames.
+- Tools (via `#[tool_router]`/`#[tool]`, `rmcp` crate):
+  - `get_lyrics`: mirrors `GET /api/get` (track/artist/album/duration).
+  - `get_lyrics_by_id`: mirrors `GET /api/get/:track_id`.
+  - `search_lyrics`: mirrors `GET /api/search`, returns `{ tracks: [...] }` (MCP tool output schemas must be a JSON object at the root, so results are wrapped rather than returned as a bare array).
+- Tools call `repositories::track_repository` functions directly through `AppState::db_connection()`. They deliberately do **not** go through the HTTP-only `get_metadata_cache`/`search_cache` (those are keyed by cache-key builders private to the `/api` route handlers); MCP traffic is expected to be much lower than public HTTP traffic, so this was kept simple rather than sharing/refactoring the caching layer.
+- Publish/flag are intentionally not exposed as MCP tools: they require a proof-of-work challenge/token flow (`request_challenge`, `utils::is_valid_publish_token`) that doesn't map cleanly onto a single tool call.
 
 ## Queue Status
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,12 +28,6 @@ name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -126,13 +105,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -209,21 +188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,18 +239,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.38"
+name = "chacha20"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
- "android-tzdata",
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -394,6 +368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,8 +425,18 @@ version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.9",
+ "darling_macro 0.20.9",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -461,12 +454,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.57",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.9",
+ "quote",
+ "syn 2.0.57",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.57",
 ]
@@ -503,6 +520,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "encoding_rs"
@@ -568,12 +591,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -581,6 +620,23 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
@@ -611,9 +667,13 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -641,10 +701,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.1"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "h2"
@@ -697,12 +763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -805,7 +865,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.6",
  "tokio",
  "tower",
  "tower-service",
@@ -925,9 +985,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1003,23 +1063,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1041,7 +1092,7 @@ dependencies = [
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror",
+ "thiserror 1.0.59",
  "triomphe",
  "uuid",
 ]
@@ -1091,25 +1142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1181,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1232,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1280,6 +1318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "r2d2"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,7 +1353,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1319,7 +1374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1328,8 +1383,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.14",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-cpuid"
@@ -1347,6 +1408,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1446,11 +1527,55 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.14",
  "libc",
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.2",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1478,12 +1603,6 @@ dependencies = [
  "log",
  "rusqlite",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
@@ -1557,6 +1676,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.57",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,18 +1724,39 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1599,13 +1765,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1663,18 +1831,20 @@ dependencies = [
  "num-bigint",
  "r2d2",
  "r2d2_sqlite",
- "rand",
+ "rand 0.8.5",
  "regex",
  "reqwest",
+ "rmcp",
  "rusqlite",
  "rusqlite_migration",
+ "schemars",
  "secular",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
  "subtle",
- "thiserror",
+ "thiserror 1.0.59",
  "tokio",
  "tower-http",
  "tracing",
@@ -1690,7 +1860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "digest",
 ]
 
@@ -1738,10 +1908,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "strsim"
@@ -1777,6 +1970,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,7 +2004,16 @@ version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.59",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -1812,6 +2025,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.57",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1872,28 +2096,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1908,6 +2130,17 @@ checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2106,8 +2339,8 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
- "getrandom",
- "rand",
+ "getrandom 0.2.14",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2132,7 +2365,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55591299b7007f551ed1eb79a684af7672c19c3193fb9e0a31936987bb2438ec"
 dependencies = [
- "darling",
+ "darling 0.20.9",
  "once_cell",
  "proc-macro-error",
  "proc-macro2",
@@ -2290,6 +2523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,6 +2544,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2456,3 +2704,9 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ You have two environment variables available to tweak the database connection:
 
 Use these variables to optimize memory usage in low traffic and/or low memory situations. The default values are generously sized to be used on a production system.
 
+## MCP support
+
+Alongside the REST API, the server exposes a read-only [Model Context Protocol](https://modelcontextprotocol.io) endpoint at `/mcp` (Streamable HTTP transport), so MCP-aware clients (e.g. Claude) can look up lyrics directly as tools instead of calling the REST API by hand. It runs on the same host/port as the rest of the API and requires no extra setup.
+
+Tools exposed: `get_lyrics` (by track/artist/album/duration), `get_lyrics_by_id` (by numeric track id), `search_lyrics` (free-text search). Publishing/flagging lyrics is intentionally not exposed over MCP.
+
+Example client config, pointing at a locally running server:
+
+```json
+{
+  "mcpServers": {
+    "lrclib": {
+      "url": "http://localhost:3300/mcp"
+    }
+  }
+}
+```
+
 ## Setup with Podman/Docker
 
 ### Basic
@@ -55,6 +73,16 @@ Run the following command to directly interact with the database in command line
 ```
 podman run --rm -it -v lrclib-data:/data lrclib-rs:latest sqlite3 /data/db.sqlite3
 ```
+
+### Docker Compose
+
+A `docker-compose.yml` is included, building the image locally and bind-mounting `./lrclib-data` (containing `db.sqlite3`) to `/data`:
+
+```
+docker compose up -d --build
+```
+
+Server will be available at http://0.0.0.0:3300. Edit `docker-compose.yml` to change the port mapping or set `LRCLIB_MMAP_SIZE`/`LRCLIB_CACHE_SIZE`/`LRCLIB_MANAGE_TOKEN`/`LRCLIB_WORKERS_COUNT`.
 
 ### Quadlet
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  lrclib:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3300:3300"
+    volumes:
+      - ./lrclib-data:/data
+    environment:
+      LRCLIB_LOG: info
+      # LRCLIB_MMAP_SIZE: "30000000000"
+      # LRCLIB_CACHE_SIZE: "-1000000"
+      # LRCLIB_MANAGE_TOKEN: ""
+      # LRCLIB_WORKERS_COUNT: "0"
+    restart: unless-stopped

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -38,3 +38,5 @@ num-bigint = "0.4.6"
 crossbeam-queue = "0.3"
 subtle = "2.6.1"
 dashmap = "6.1.0"
+rmcp = { version = "2.2.0", features = ["server", "macros", "transport-streamable-http-server"] }
+schemars = "1.2.1"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -9,11 +9,15 @@ use crossbeam_queue::ArrayQueue;
 use dashmap::DashMap;
 use db::init_db;
 use entities::missing_track::MissingTrack;
+use mcp::LrclibMcpServer;
 use moka::future::Cache;
 use r2d2::Pool;
 use r2d2::PooledConnection;
 use r2d2_sqlite::SqliteConnectionManager;
 use repositories::lyrics_repository::get_last_10_mins_lyrics_count;
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+};
 use routes::get_lyrics_by_metadata::TrackResponse as GetLyricsByMetadataResponse;
 use routes::search_lyrics::CachedResult;
 use routes::{
@@ -37,6 +41,7 @@ use tracing_subscriber::EnvFilter;
 pub mod db;
 pub mod entities;
 pub mod errors;
+pub mod mcp;
 #[path = "queue_stub.rs"]
 pub mod queue;
 pub mod repositories;
@@ -124,8 +129,22 @@ fn build_router(state: Arc<AppState>, state_for_logging: Arc<AppState>) -> Route
     // Add management routes to the API router
     let api_routes = api_routes.nest("/manage", manage_routes);
 
+    // Build the MCP (Model Context Protocol) service, sharing the same AppState
+    let mcp_service = StreamableHttpService::new(
+        {
+            let state = state.clone();
+            move || Ok(LrclibMcpServer::new(state.clone()))
+        },
+        LocalSessionManager::default().into(),
+        // Same trust model as the rest of the public API (open CORS, no Host allowlist):
+        // this server is designed to run behind arbitrary reverse proxies, so the
+        // default loopback-only `Host` allowlist (DNS-rebinding protection) is disabled.
+        StreamableHttpServerConfig::default().disable_allowed_hosts(),
+    );
+
     Router::new()
         .nest("/api", api_routes)
+        .nest_service("/mcp", mcp_service)
         .with_state(state)
         .layer(
             TraceLayer::new_for_http()

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -1,0 +1,199 @@
+use crate::{
+    entities::track::SimpleTrack,
+    repositories::track_repository::{
+        get_track_by_id, get_track_by_metadata, get_tracks_by_keyword,
+    },
+    utils::process_param,
+    AppState,
+};
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{Implementation, ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, Json, ServerHandler,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackResponse {
+    id: i64,
+    name: Option<String>,
+    track_name: Option<String>,
+    artist_name: Option<String>,
+    album_name: Option<String>,
+    duration: Option<f64>,
+    instrumental: bool,
+    plain_lyrics: Option<String>,
+    synced_lyrics: Option<String>,
+    lyricsfile: Option<String>,
+}
+
+impl From<SimpleTrack> for TrackResponse {
+    fn from(track: SimpleTrack) -> Self {
+        let (instrumental, plain_lyrics, synced_lyrics, lyricsfile) = match track.last_lyrics {
+            Some(lyrics) => (
+                lyrics.instrumental,
+                lyrics.plain_lyrics,
+                lyrics.synced_lyrics,
+                lyrics.lyricsfile,
+            ),
+            None => (false, None, None, None),
+        };
+
+        TrackResponse {
+            id: track.id,
+            name: track.name.clone(),
+            track_name: track.name,
+            artist_name: track.artist_name,
+            album_name: track.album_name,
+            duration: track.duration,
+            instrumental,
+            plain_lyrics,
+            synced_lyrics,
+            lyricsfile,
+        }
+    }
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub struct GetLyricsRequest {
+    /// Song title.
+    pub track_name: String,
+    /// Performing artist.
+    pub artist_name: String,
+    /// Album title. Improves match accuracy when known.
+    pub album_name: Option<String>,
+    /// Track duration in seconds. Improves match accuracy when known.
+    pub duration: Option<f64>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub struct GetLyricsByIdRequest {
+    /// LRCLIB numeric track id, as returned by other lyrics tools.
+    pub track_id: i64,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub struct SearchLyricsResponse {
+    tracks: Vec<TrackResponse>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub struct SearchLyricsRequest {
+    /// Free-text search query, matched across track/artist/album fields.
+    pub q: Option<String>,
+    /// Restrict/boost results to this track name.
+    pub track_name: Option<String>,
+    /// Restrict/boost results to this artist name.
+    pub artist_name: Option<String>,
+    /// Restrict/boost results to this album name.
+    pub album_name: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct LrclibMcpServer {
+    state: Arc<AppState>,
+    tool_router: ToolRouter<Self>,
+}
+
+impl LrclibMcpServer {
+    pub fn new(state: Arc<AppState>) -> Self {
+        Self {
+            state,
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl LrclibMcpServer {
+    #[tool(
+        description = "Look up synced/plain lyrics for a track by track name, artist name, and optionally album name/duration. Returns a not-found error if there is no close match."
+    )]
+    async fn get_lyrics(
+        &self,
+        Parameters(params): Parameters<GetLyricsRequest>,
+    ) -> Result<Json<TrackResponse>, String> {
+        let track_name_lower = process_param(Some(params.track_name.as_str()));
+        let artist_name_lower = process_param(Some(params.artist_name.as_str()));
+        let album_name_lower = process_param(params.album_name.as_deref());
+
+        let (track_name_lower, artist_name_lower) = match (track_name_lower, artist_name_lower) {
+            (Some(track_name_lower), Some(artist_name_lower)) => {
+                (track_name_lower, artist_name_lower)
+            }
+            _ => return Err("track_name and artist_name must not be empty".to_owned()),
+        };
+
+        let mut conn = self.state.db_connection().map_err(|e| e.to_string())?;
+        let track = get_track_by_metadata(
+            &track_name_lower,
+            &artist_name_lower,
+            album_name_lower.as_deref(),
+            params.duration,
+            &mut conn,
+        )
+        .map_err(|e| e.to_string())?;
+
+        match track {
+            Some(track) => Ok(Json(track.into())),
+            None => Err("No matching track found".to_owned()),
+        }
+    }
+
+    #[tool(description = "Look up lyrics for a track by its LRCLIB numeric track id.")]
+    async fn get_lyrics_by_id(
+        &self,
+        Parameters(params): Parameters<GetLyricsByIdRequest>,
+    ) -> Result<Json<TrackResponse>, String> {
+        let mut conn = self.state.db_connection().map_err(|e| e.to_string())?;
+        let track = get_track_by_id(params.track_id, &mut conn).map_err(|e| e.to_string())?;
+
+        match track {
+            Some(track) => Ok(Json(track.into())),
+            None => Err("No track found with that id".to_owned()),
+        }
+    }
+
+    #[tool(
+        description = "Search LRCLIB for tracks/lyrics by free-text query and/or track/artist/album name. Returns an empty list rather than an error when nothing matches."
+    )]
+    async fn search_lyrics(
+        &self,
+        Parameters(params): Parameters<SearchLyricsRequest>,
+    ) -> Result<Json<SearchLyricsResponse>, String> {
+        let q = process_param(params.q.as_deref());
+        let track_name = process_param(params.track_name.as_deref());
+        let artist_name = process_param(params.artist_name.as_deref());
+        let album_name = process_param(params.album_name.as_deref());
+
+        let mut conn = self.state.db_connection().map_err(|e| e.to_string())?;
+        let tracks = get_tracks_by_keyword(
+            q.as_deref(),
+            track_name.as_deref(),
+            artist_name.as_deref(),
+            album_name.as_deref(),
+            &mut conn,
+        )
+        .map_err(|e| e.to_string())?;
+
+        Ok(Json(SearchLyricsResponse {
+            tracks: tracks.into_iter().map(TrackResponse::from).collect(),
+        }))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for LrclibMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("lrclib", env!("CARGO_PKG_VERSION")))
+            .with_instructions(
+                "Look up synchronized and plain lyrics from LRCLIB (lrclib.net). Use get_lyrics when \
+                 you know the track and artist (add album/duration for a more precise match), \
+                 get_lyrics_by_id when you already have a numeric LRCLIB track id, and search_lyrics \
+                 for free-text discovery across multiple tracks.",
+            )
+    }
+}

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -26,19 +26,17 @@ pub struct TrackResponse {
     instrumental: bool,
     plain_lyrics: Option<String>,
     synced_lyrics: Option<String>,
-    lyricsfile: Option<String>,
 }
 
 impl From<SimpleTrack> for TrackResponse {
     fn from(track: SimpleTrack) -> Self {
-        let (instrumental, plain_lyrics, synced_lyrics, lyricsfile) = match track.last_lyrics {
+        let (instrumental, plain_lyrics, synced_lyrics) = match track.last_lyrics {
             Some(lyrics) => (
                 lyrics.instrumental,
                 lyrics.plain_lyrics,
                 lyrics.synced_lyrics,
-                lyrics.lyricsfile,
             ),
-            None => (false, None, None, None),
+            None => (false, None, None),
         };
 
         TrackResponse {
@@ -51,7 +49,6 @@ impl From<SimpleTrack> for TrackResponse {
             instrumental,
             plain_lyrics,
             synced_lyrics,
-            lyricsfile,
         }
     }
 }
@@ -109,7 +106,9 @@ impl LrclibMcpServer {
 #[tool_router]
 impl LrclibMcpServer {
     #[tool(
-        description = "Look up synced/plain lyrics for a track by track name, artist name, and optionally album name/duration. Returns a not-found error if there is no close match."
+        title = "Get lyrics by metadata",
+        description = "Look up synced/plain lyrics for a track by track name, artist name, and optionally album name/duration. Returns a not-found error if there is no close match.",
+        annotations(read_only_hint = true, open_world_hint = false)
     )]
     async fn get_lyrics(
         &self,
@@ -142,7 +141,11 @@ impl LrclibMcpServer {
         }
     }
 
-    #[tool(description = "Look up lyrics for a track by its LRCLIB numeric track id.")]
+    #[tool(
+        title = "Get lyrics by track id",
+        description = "Look up lyrics for a track by its LRCLIB numeric track id.",
+        annotations(read_only_hint = true, open_world_hint = false)
+    )]
     async fn get_lyrics_by_id(
         &self,
         Parameters(params): Parameters<GetLyricsByIdRequest>,
@@ -157,7 +160,9 @@ impl LrclibMcpServer {
     }
 
     #[tool(
-        description = "Search LRCLIB for tracks/lyrics by free-text query and/or track/artist/album name. Returns an empty list rather than an error when nothing matches."
+        title = "Search lyrics",
+        description = "Search LRCLIB for tracks/lyrics by free-text query and/or track/artist/album name. Returns an empty list rather than an error when nothing matches.",
+        annotations(read_only_hint = true, open_world_hint = false)
     )]
     async fn search_lyrics(
         &self,


### PR DESCRIPTION
Adds a read-only [Model Context Protocol](https://modelcontextprotocol.io) server, exposed
alongside the existing REST API, so MCP-aware clients (Claude, etc.) can look up lyrics
directly as tools instead of calling the REST API by hand.

- Using the [mcp rust sdk](https://github.com/modelcontextprotocol/rust-sdk)
- New `/mcp` endpoint for Streamable HTTP transport
- Three tools in `server/src/mcp.rs`, mirroring the existing GET routes:
  - `get_lyrics` — by track/artist/album/duration (mirrors `GET /api/get`)
  - `get_lyrics_by_id` — by numeric track id (mirrors `GET /api/get/:track_id`)
  - `search_lyrics` — free-text/metadata search (mirrors `GET /api/search`)
- Lyricsfile is left out of mcp responses as they do not provide additional context for the llm.
- All tools are properly annotated as read-only/not open-world

Manually verified end-to-end against a full production-sized database via
`docker compose up -d --build`:
- `initialize` → `tools/list` → `tools/call` for all three tools, including a not-found
  case returning `isError: true`.
- `tools/list` output includes correct `title`/`annotations`/`outputSchema` per tool, and
  no `lyricsfile` field in tool results.
- `initialize` succeeds with a non-loopback `Host` header (simulating a reverse proxy).
- Existing `/api/get`, `/api/get/:track_id`, `/api/search` endpoints unaffected, and still
  return `lyricsfile` as before.

Closes #71 